### PR TITLE
Extra mouse buttons and sound options menu spacing

### DIFF
--- a/gameroot/uo/ui/options_sound.menu
+++ b/gameroot/uo/ui/options_sound.menu
@@ -101,7 +101,7 @@ menuDef
 		text "@MENU_SUBTITLES"
 		cvar "cg_subtitles"
 //		cvarfloat "mss_volume" 0.8 0 1
-		rect 5 70 OPTIONS_CONTROL_SIZE
+		rect 5 75 OPTIONS_CONTROL_SIZE
 		textalign ITEM_ALIGN_RIGHT
 		textalignx 100
 		textaligny 10
@@ -126,7 +126,7 @@ menuDef
 		type ITEM_TYPE_SLIDER
 		text "@MENU_MASTER_VOLUME"
 		cvarfloat "mss_volume" 0.8 0 1
-		rect 5 100 OPTIONS_CONTROL_SIZE
+		rect 5 95 OPTIONS_CONTROL_SIZE
 		textalign ITEM_ALIGN_RIGHT
 		textalignx 100
 		textaligny 10
@@ -148,7 +148,7 @@ menuDef
 		type ITEM_TYPE_SLIDER
 		text "@MENU_MUSIC_VOLUME"
 		cvarfloat "mss_volume_music" 1 0 1
-		rect 5 130 OPTIONS_CONTROL_SIZE
+		rect 5 115 OPTIONS_CONTROL_SIZE
 		textalign ITEM_ALIGN_RIGHT
 		textalignx 100
 		textaligny 10
@@ -171,7 +171,7 @@ menuDef
 		type ITEM_TYPE_SLIDER
 		text "@MENU_EFFECTS_VOLUME"
 		cvarfloat "mss_volume_effects" 1 0 1
-		rect 5 160 OPTIONS_CONTROL_SIZE
+		rect 5 135 OPTIONS_CONTROL_SIZE
 		textalign ITEM_ALIGN_RIGHT
 		textalignx 100
 		textaligny 10
@@ -194,7 +194,7 @@ menuDef
 		type ITEM_TYPE_SLIDER
 		text "Voice Volume:   "
 		cvarfloat "mss_volume_voice" 1 0 1
-		rect 5 190 OPTIONS_CONTROL_SIZE
+		rect 5 155 OPTIONS_CONTROL_SIZE
 		textalign ITEM_ALIGN_RIGHT
 		textalignx 100
 		textaligny 10
@@ -221,7 +221,7 @@ menuDef
 				"@MENU_44KHZ__" 44 
 				}
 //		rect 17.5 130 290 12
-		rect 5 220 OPTIONS_CONTROL_SIZE
+		rect 5 175 OPTIONS_CONTROL_SIZE
 		textalign ITEM_ALIGN_RIGHT
 //		textalignx 142
 //		textaligny 10
@@ -280,7 +280,7 @@ menuDef
 				"@MENU_CREATIVE_LABS_EAX", "Creative Labs EAX (TM)",
 				"@MENU_MILES_FAST_2D_POSITIONAL_AUDIO", "Miles Fast 2D Positional Audio"
 				}
-		rect 5 250 OPTIONS_CONTROL_SIZE
+		rect 5 195 OPTIONS_CONTROL_SIZE
 		textalign ITEM_ALIGN_RIGHT
 		textalignx 100
 		textaligny 10

--- a/src/rinput.cpp
+++ b/src/rinput.cpp
@@ -44,8 +44,6 @@ namespace rinput {
 			rawinput_x_old = rawinput_x_current;
 			rawinput_y_old = rawinput_y_current;
 
-			POINT cursorPos;
-			GetCursorPos(&cursorPos);
 			SetCursorPos(*window_center_x, *window_center_y);
 			Sys_QueEvent(3, delta_x, delta_y, 0, NULL);
 		}

--- a/src/rinput.cpp
+++ b/src/rinput.cpp
@@ -75,10 +75,10 @@ namespace rinput {
 
 	static void rawInput_init(HWND hWnd)
 	{
-		RAWINPUTDEVICE rid[1]{};
+		RAWINPUTDEVICE rid[1];
 		rid[0].usUsagePage = HID_USAGE_PAGE_GENERIC;
 		rid[0].usUsage = HID_USAGE_GENERIC_MOUSE;
-		rid[0].dwFlags = RIDEV_INPUTSINK;
+		rid[0].dwFlags = 0;
 		rid[0].hwndTarget = hWnd;
 		if (!RegisterRawInputDevices(rid, ARRAYSIZE(rid), sizeof(rid[0])))
 			throw std::runtime_error("RegisterRawInputDevices failed");


### PR DESCRIPTION
Every Call of Duty since CoD2 supports binding mouse buttons 4 and 5. Original id Tech 3 engine supports them partially, eg. DirectInput backend supports button 4, Linux code supports both while plain WIN32 window message code only supports first 3. CoD only inherited the latter code, so I've addressed the omission with the extra buttons.

Did some minor corrections on some functions' names / parameters / return types, the ones dealing with mouse input. Small, insignificant, shouldn't change anything from outsider's perspective. And I suppose there isn't any reason I'm aware of why WM_INPUT messages should be sent to the game window if user isn't interacting with it.

Finally, the modified sound menu with extra volume sliders, the last option overlaps with Sound Blaster logo when **Creative Labs EAX 3 (TM)** is selected as sound provider, so I reduced spacing in the menu and moved options down a bit, looks most centered between the logo and the header this way.

![Sound options menu](https://i.imgur.com/l1NVTuI.png)